### PR TITLE
Fix routing so that about page shows up

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,9 +15,9 @@ function App() {
         </div>
         <main className="font-mono text-lg">
           <Switch>
-            <Route path="/" component={LandingPage} />
             <Route path="/home" component={LandingPage} />
             <Route path="/about" component={AboutPage} />
+            <Route path="/" component={LandingPage} />
           </Switch>
         </main>
         <div>


### PR DESCRIPTION
It seems that the order in which you specify the routing switch statements matters; the /home page was overriding the /about page so that the about page never showed up. 