### PR TITLE
Style axes selection along respective axes

### DIFF
--- a/src/modules/stateSpaces/pca/PCA.css
+++ b/src/modules/stateSpaces/pca/PCA.css
@@ -1,13 +1,3 @@
-/* .pca.raw-data-table thead {
-    display: block;
-}
-
-.pca.raw-data-table tbody {
-    display: block;
-    overflow-y: auto;
-    height: 350px;
-} */
-
 .pca.raw-data-table {
     height: 350px;
     width: 600px;
@@ -35,30 +25,51 @@
 }
 
 .pca.raw-data-chart {
-    display: flex;
+    display: grid;
+    grid-template-columns: min-content auto;
+    grid-template-rows: auto min-content;
     align-items: center;
-    justify-content: space-evenly;
+    justify-items: center;
     margin: 10px;
 }
 
-.pca.raw-data-chart .chart-config {
+.pca.raw-data-chart .yIdx {
+    grid-column: 1;
+    grid-row: 1;
+}
+
+.pca.raw-data-chart .xIdx {
+    grid-column: 2;
+    grid-row: 2;
     display: flex;
-    justify-content: center;
+    align-items: center;
+}
+
+.pca.raw-data-chart .xIdx > p {
+    margin: 0 7px;
 }
 
 .pca.raw-data-chart .axis-selector {
     display: flex;
+}
+
+.pca.raw-data-chart .yIdx .axis-selector {
     flex-direction: column;
     margin: 0px 16px;
+}
+
+.pca.raw-data-chart .xIdx .axis-selector {
+    margin: 16px 0px;
 }
 
 .pca.raw-data-chart .axis-selector button {
     border: none;
     outline: none;
-    padding: 10px;
+    padding: 7px 10px;
     margin: 1px;
     background-color: #8D9DBA;
     font-weight: bold;
+    font-size: 12pt;
     color: #f2f2f2;
 }
 
@@ -71,12 +82,12 @@
 }
 
 .pca.raw-data-chart .raw-data-scatter {
-    position: relative;
-    width: 70%;
-    float: right;
+    grid-column: 2;
+    grid-row: 1;
+    width: 100%;
+    height: 100%;
 }
 
 .pca.pca-chart {
-    width: 70%;
     margin: auto;
 }

--- a/src/modules/stateSpaces/pca/PCA.tsx
+++ b/src/modules/stateSpaces/pca/PCA.tsx
@@ -14,9 +14,9 @@ const PCADemo = (props: { labelColor: string }) => {
     return (
         <div className={`PCA-div ${props.labelColor}`}>
             <RawDataTable />
-            <StaticAxisChart xIdx={2} yIdx={3} columnSet={columns} classes={["versicolor", "setosa"]}/>
-            <SelectableAxisChart columnSet={columns} />
-            <SelectableAxisChart columnSet={pcaColumns} />
+            <StaticAxisChart xIdx={4} yIdx={5} columnSet={columns} classes={["versicolor", "setosa"]} />
+            <SelectableAxisChart columnSet={columns} initXIdx={2} initYIdx={3} />
+            <SelectableAxisChart columnSet={pcaColumns} initXIdx={0} initYIdx={1} />
         </div>
     );
 }
@@ -25,7 +25,7 @@ const RawDataTable = () =>
     <div className="pca raw-data-table">
         <table>
             <thead>
-                <tr>{columns.map(title => <th key={title}>{title}</th>)}<th>Class</th></tr>
+                <tr>{columns.map(title => title && <th key={title}>{title}</th>)}<th>Class</th></tr>
             </thead>
             <tbody>
                 {dataset.map((row: number[], idx: number) => {
@@ -41,9 +41,9 @@ const RawDataTable = () =>
 
 
 // Plot all samples in dataset, choose what 2 features to use as the axes
-const SelectableAxisChart = (props: { columnSet: string[] }) => {
-    const [xIdx, setXIdx] = useState(0);
-    const [yIdx, setYIdx] = useState(1);
+const SelectableAxisChart = (props: { columnSet: string[], initXIdx: number, initYIdx: number }) => {
+    const [xIdx, setXIdx] = useState(props.initXIdx);
+    const [yIdx, setYIdx] = useState(props.initYIdx);
     const points: DataSeriesMap = {};
     Object.entries(dataByClass).forEach(([dataClass, nums]) => {
         points[dataClass] = nums.map(row => ({ x: row[xIdx], y: row[yIdx] }));
@@ -51,18 +51,16 @@ const SelectableAxisChart = (props: { columnSet: string[] }) => {
 
     return (
         <div className="pca raw-data-chart">
-            <div className="chart-config">
-                <div className="select-axis-menu xIdx">
-                    <p className="font-opensans font-bold italic"> Select X Axis</p>
-                    <AxisSelector selected={xIdx} onChange={setXIdx} columnSet={props.columnSet} />
-                </div>
-                <div className="select-axis-menu yIdx">
-                    <p className="font-opensans font-bold italic"> Select Y Axis </p>
-                    <AxisSelector selected={yIdx} onChange={setYIdx} columnSet={props.columnSet} />
-                </div>
+            <div className="select-axis-menu yIdx">
+                <p className="font-opensans font-bold italic"> Select Y Axis </p>
+                <AxisSelector selected={yIdx} onChange={setYIdx} columnSet={props.columnSet} />
             </div>
             <div className="raw-data-scatter">
                 <BasicScatter colorMap={colorMap} points={points} xLabel={props.columnSet[xIdx]} yLabel={props.columnSet[yIdx]} />
+            </div>
+            <div className="select-axis-menu xIdx">
+                <p className="font-opensans font-bold italic"> Select X Axis</p>
+                <AxisSelector selected={xIdx} onChange={setXIdx} columnSet={props.columnSet} />
             </div>
         </div>);
 };
@@ -87,7 +85,7 @@ const StaticAxisChart = (props: { xIdx: number, yIdx: number, columnSet: string[
 const AxisSelector = (props: { columnSet: string[], selected: number, onChange: (arg: number) => void }) =>
     (<div className="axis-selector">
         {props.columnSet.map((col, idx) => (
-            <button
+            col && <button
                 className={props.selected === idx ? "selected" : ""}
                 key={col}
                 onClick={() => props.onChange(idx)}>
@@ -101,8 +99,8 @@ const COLORS = ['#003f5c', '#ef5675', '#FFC107', '#00B0FF', '#FF3D00', '#4DB6AC'
 // Moving these outside so they are only calculated once (this will change if we dynamically get datasets)
 const dataset: number[][] = datasetIris.getNumbers(); // rows represent the samples and columns the features
 const classes: string[] = datasetIris.getClasses(); // the whole column of flower types
-const columns = ['Sepal Length', 'Sepal Width', 'Petal Length', 'Petal Width'];
-const pcaColumns = ['Sepal Length', 'Sepal Width', 'Petal Length', 'Petal Width', 'PC1', 'PC2'];
+const columns = ['', '', 'Sepal Length', 'Sepal Width', 'Petal Length', 'Petal Width'];
+const pcaColumns = ['PC1', 'PC2', 'Sepal Length', 'Sepal Width', 'Petal Length', 'Petal Width'];
 const prediction = new PCA(dataset).predict(dataset);
 
 const colorMap: ColorMap = {};
@@ -112,7 +110,7 @@ datasetIris.getDistinctClasses().forEach((dataClass: string, i: number) => {
     dataByClass[dataClass] = [];
     dataset.forEach((row, idx) => {
         if (dataClass === classes[idx]) {
-            dataByClass[dataClass].push(row.concat([prediction.get(idx, 0), prediction.get(idx, 1)]));
+            dataByClass[dataClass].push([prediction.get(idx, 0), prediction.get(idx, 1)].concat(row));
         }
     });
 })


### PR DESCRIPTION
Align x axis selection along the x axis, and the y axis along the y axis. 

Also put the PC1 /  PC2 vectors first in the selections, so they show up first if they are present. 

Added props to selectable axes graphs to configure the initial x/y axes. 